### PR TITLE
fix: remove flag check

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -118,7 +118,7 @@ impl Emulator {
 
     /// Start executing the emulator.
     pub fn start(&mut self) -> Result<(), Exception> {
-        if self.is_debug || self.cpu.is_count {
+        if self.is_debug {
             self.debug_start();
         }
 


### PR DESCRIPTION
Removes additional flag check so that one can count instructions executed without going into debug mode.